### PR TITLE
Refactor code into reusable module and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,26 @@
-# Welcome to Streamlit!
+# Butterworth Low-Pass Filter Design
 
-Edit `/streamlit_app.py` to customize this app to your heart's desire. :heart:
+A Streamlit application that calculates Butterworth low-pass filter coefficients and visualizes the filter's frequency response.
 
-If you have any questions, checkout our [documentation](https://docs.streamlit.io) and [community
-forums](https://discuss.streamlit.io).
+## Features
+- Adjust filter order, sampling frequency, and cutoff frequency
+- View magnitude and phase response plots
+- Display numerator (b) and denominator (a) coefficients
+
+## Installation
+1. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+## Usage
+Run the Streamlit app:
+
+```bash
+streamlit run streamlit_app.py
+```
+
+Use the sidebar controls to configure the filter and inspect the results.
+
+## Requirements
+See `requirements.txt` for a list of required packages.

--- a/filter_design.py
+++ b/filter_design.py
@@ -1,0 +1,68 @@
+"""Utility functions for Butterworth low-pass filter design and visualization."""
+
+from typing import Tuple
+
+import numpy as np
+import matplotlib.pyplot as plt
+from scipy.signal import butter, freqz
+
+
+def butter_lowpass(cutoff: float, fs: float, order: int = 5) -> Tuple[np.ndarray, np.ndarray]:
+    """Design a digital Butterworth low-pass filter.
+
+    Parameters
+    ----------
+    cutoff: float
+        Cutoff frequency in Hz.
+    fs: float
+        Sampling frequency in Hz.
+    order: int, default=5
+        Order of the filter.
+
+    Returns
+    -------
+    Tuple[np.ndarray, np.ndarray]
+        Numerator (``b``) and denominator (``a``) filter coefficients.
+    """
+    nyquist = 0.5 * fs
+    normal_cutoff = cutoff / nyquist
+    b, a = butter(order, normal_cutoff, btype="low", analog=False)
+    return b, a
+
+
+def plot_filter_response(
+    b: np.ndarray, a: np.ndarray, fs: float, width: int, height: int
+) -> plt.Figure:
+    """Plot the magnitude and phase response of a digital filter.
+
+    Parameters
+    ----------
+    b, a: np.ndarray
+        Filter coefficients.
+    fs: float
+        Sampling frequency in Hz.
+    width, height: int
+        Size of the resulting chart in inches.
+
+    Returns
+    -------
+    matplotlib.figure.Figure
+        Figure containing the frequency response plot.
+    """
+    w, h = freqz(b, a)
+    fig, ax1 = plt.subplots(figsize=(width, height))
+    ax1.plot(0.5 * fs * w / np.pi, np.abs(h), "b")
+    ax1.set_xlim(0, 0.5 * fs)
+    ax1.set_ylim(0, 1.1)
+    ax1.set_xlabel("Frequency (Hz)")
+    ax1.set_ylabel("Gain", color="b")
+    ax1.grid(True)
+
+    ax2 = ax1.twinx()
+    angles = np.unwrap(np.angle(h))
+    ax2.plot(0.5 * fs * w / np.pi, angles, "g")
+    ax2.set_ylabel("Phase (radians)", color="g")
+    ax2.grid(False)
+
+    fig.suptitle("Butterworth Lowpass Filter Response")
+    return fig

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -1,48 +1,32 @@
+"""Streamlit application for designing Butterworth low-pass filters."""
+
 import streamlit as st
-import numpy as np
-import matplotlib.pyplot as plt
-from scipy.signal import butter, freqz
 
-st.set_option('deprecation.showPyplotGlobalUse', False)
+from filter_design import butter_lowpass, plot_filter_response
 
-def butter_lowpass(cutoff, fs, order=5):
-    nyquist = 0.5 * fs
-    normal_cutoff = cutoff / nyquist
-    b, a = butter(order, normal_cutoff, btype='low', analog=False)
-    return b, a
 
-def plot_filter_response(b, a, fs, width, height):
-    w, h = freqz(b, a)
-    fig, ax1 = plt.subplots(figsize=(width, height))
-    plt.subplot(1, 1, 1)
-    ax1.plot(0.5*fs*w/np.pi, abs(h), 'b')
-    ax1.set_xlim(0, 0.5*fs)
-    ax1.set_ylim(0, 1.1)
-    ax1.set_xlabel('Frequency (Hz)')
-    ax1.set_ylabel('Gain', color='b')
-    ax1.grid(True)
-    ax2 = ax1.twinx()
-    angles = np.unwrap(np.angle(h))
-    ax2.plot(0.5*fs*w/np.pi, angles, 'g')
-    ax2.set_ylabel('Phase (radians)', color='g')
-    ax2.grid(False)
-    plt.title("Butterworth Lowpass Filter Response")
+def main() -> None:
+    """Render the Streamlit user interface."""
+    st.set_page_config(page_title="Butterworth Lowpass Filter Coefficients Calculator")
+    st.title("Butterworth Lowpass Filter Coefficients Calculator")
 
-st.set_page_config(page_title="Butterworth Lowpass Filter Coefficients Calculator")
+    order = st.sidebar.slider("Filter Order", 1, 10, 2)
+    fs = st.sidebar.number_input(
+        "Sampling Frequency (Hz)", value=100, min_value=1, max_value=1000, step=1
+    )
+    cutoff = st.sidebar.number_input(
+        "Cutoff Frequency (Hz)", value=20, min_value=1, max_value=1000, step=1
+    )
+    b, a = butter_lowpass(cutoff, fs, order)
 
-st.title("Butterworth Lowpass Filter Coefficients Calculator")
+    width = st.sidebar.number_input("Chart Width", value=12, min_value=1, max_value=20, step=1)
+    height = st.sidebar.number_input("Chart Height", value=8, min_value=1, max_value=20, step=1)
 
-order = st.sidebar.slider("Filter Order", 1, 10, 2)
-fs = st.sidebar.number_input("Sampling Frequency (Hz)", value=100, min_value=1, max_value=1000, step=1)
-cutoff = st.sidebar.number_input("Cutoff Frequency (Hz)", value=20, min_value=1, max_value=1000, step=1)
+    fig = plot_filter_response(b, a, fs, width, height)
+    st.pyplot(fig)
+    st.write("Numerator (b) Coefficients: ", b)
+    st.write("Denominator (a) Coefficients: ", a)
 
-b, a = butter_lowpass(cutoff, fs, order)
 
-width = st.sidebar.number_input("Chart Width", value=12, min_value=1, max_value=20, step=1)
-height = st.sidebar.number_input("Chart Height", value=8, min_value=1, max_value=20, step=1)
-
-plot_filter_response(b, a, fs, width, height)
-st.pyplot()
-
-st.write("Numerator (b) Coefficients: ", b)
-st.write("Denominator (a) Coefficients: ", a)
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Factor out Butterworth filter utilities into a dedicated module
- Streamline Streamlit app to use modular functions
- Rewrite README with instructions and feature overview

## Testing
- `python -m py_compile streamlit_app.py filter_design.py`


------
https://chatgpt.com/codex/tasks/task_e_689a6bf24ea0832aae266b939ebc2abf